### PR TITLE
Release v1.0.0-ALPHA.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v1.0.0-ALPHA.18
+
+- [BREAKING][discord]: The `args` property in `ICommandContext` is now a `Map<string, MsgArgs>` instead of `MsgArgs[]`;
+  - Arguments are now keyed by their parameter name (lowercase), matching the behavior of slash commands;
+  - This affects both legacy (prefix) commands and slash commands;
+  - Update any code that accesses `context.args` by index (e.g. `args[0]`) to use `args.get('paramName')` instead;
+
+- [FEAT][discord]: Legacy commands now support named arguments;
+  - Arguments can be passed by name using the `--name=value` or `-name:value` syntax, in addition to the traditional positional syntax;
+  - Positional and named arguments can be mixed freely;
+
+- [FEAT][discord]: The last `String` parameter of a legacy command now automatically captures all remaining positional tokens as a single joined string;
+
+- [FIX][discord]: Passing extra positional arguments that exceed the command's parameter count now returns a clear error message instead of silently being appended to the last argument;
+  - Unknown named arguments also produce a clear error message;
+
+- [FIX][discord]: User, channel, and role resolution now correctly strips mention formatting (e.g. `<@123>`, `<#456>`, `<@&789>`) before resolving by ID;
+
+- [FIX][discord]: Integer validation now uses a strict regex (`/^-?\d+$/`) instead of `parseInt`, preventing strings like `"12abc"` from being accepted as valid integers;
+
+- [FIX][discord]: Number validation now uses `Number()` instead of `parseFloat`, improving consistency with JavaScript's standard numeric coercion;
+
+- [FIX][discord]: Subcommand and SubcommandGroup option types are now excluded from parameter iteration and the usage string, preventing them from being treated as regular arguments;
+
+- [CHORE]: Bump dependencies;
+
 ## v1.0.0-ALPHA.17
 
 - [FEAT][discord]: Expose `showModal` method in the command context;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arunabase",
-  "version": "1.0.0-ALPHA.17",
+  "version": "1.0.0-ALPHA.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "arunabase",
-      "version": "1.0.0-ALPHA.17",
+      "version": "1.0.0-ALPHA.18",
       "license": "GPL-3.0",
       "dependencies": {
         "@promisepending/logger.js": "^1.1.1",
@@ -16,7 +16,7 @@
         "path-to-regexp": "^8.3.0"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.56.1",
+        "@typescript-eslint/eslint-plugin": "^8.57.0",
         "eslint": "^9.39.2",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-node": "^11.1.0",
@@ -477,17 +477,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
+      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/type-utils": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -500,7 +500,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.57.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -516,17 +516,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -542,14 +542,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -564,14 +564,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -599,15 +599,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
+      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -638,16 +638,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -705,16 +705,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -729,13 +729,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.57.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4182,16 +4182,16 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
+      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
       "dev": true,
       "requires": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/type-utils": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -4206,76 +4206,76 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "debug": "^4.4.3"
       }
     },
     "@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
         "debug": "^4.4.3"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
       }
     },
     "@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
       "dev": true,
       "requires": {}
     },
     "@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
+      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4290,18 +4290,18 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-          "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
           }
         },
         "minimatch": {
-          "version": "10.2.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-          "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+          "version": "10.2.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+          "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^5.0.2"
@@ -4310,24 +4310,24 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.57.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "dependencies": {
@@ -5741,9 +5741,9 @@
       }
     },
     "minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^7.2.1",
-        "globals": "^17.3.0",
+        "globals": "^17.4.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2189,9 +2189,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
-      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5209,9 +5209,9 @@
       }
     },
     "flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true
     },
     "follow-redirects": {
@@ -5312,9 +5312,9 @@
       }
     },
     "globals": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
-      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
       "dev": true
     },
     "globalthis": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arunabase",
-  "version": "1.0.0-ALPHA.17",
+  "version": "1.0.0-ALPHA.18",
   "description": "An API made to help developers what works with discord and twitch.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -44,7 +44,7 @@
     "path-to-regexp": "^8.3.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/eslint-plugin": "^8.57.0",
     "eslint": "^9.39.2",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.2.1",
-    "globals": "^17.3.0",
+    "globals": "^17.4.0",
     "typescript": "^5.9.3"
   }
 }

--- a/src/main/discord/interfaces/ICommandContext.ts
+++ b/src/main/discord/interfaces/ICommandContext.ts
@@ -21,6 +21,7 @@ import {
 import { DiscordClient, MessageStructure } from '..';
 
 export type MsgArgs = string | number | boolean | User | APIRole | Role | GuildBasedChannel | APIInteractionDataResolvedChannel | Attachment | null | undefined;
+export type MsgArgsMap = Map<string, MsgArgs>;
 
 interface IBaseCommandContext {
   client: DiscordClient;
@@ -38,7 +39,7 @@ interface IBaseCommandContext {
   deferReply: (ephemeral?: boolean) => Promise<void | InteractionResponse<boolean>>;
 
   messageReplyContent?: Message<boolean> | null;
-  args: MsgArgs[];
+  args: MsgArgsMap;
   author: User;
   member?: GuildMember | null;
   guild?: Guild | null;

--- a/src/main/discord/listeners/handlers/MessageHandler.ts
+++ b/src/main/discord/listeners/handlers/MessageHandler.ts
@@ -9,7 +9,7 @@ import {
 import { CommandStructureBased, MessageStructure } from '../../structures';
 import { CommandListener, MsgParams } from '../CommandListener';
 import { ButtonManager, CommandManager } from '../../managers';
-import { ICommandContext, MsgArgs } from '../../interfaces';
+import { ICommandContext, MsgArgs, MsgArgsMap } from '../../interfaces';
 import { DiscordClient } from '../../Client';
 import { RichEmbed } from '../../utils';
 
@@ -35,7 +35,7 @@ export class MessageHandler {
 
     const [command, args] = this.parseArgs(message, prefix, isDM);
     
-    if (!command) return;
+    if (!command || args == null) return;
 
     const context: ICommandContext = {
       client: this.client,
@@ -110,14 +110,14 @@ export class MessageHandler {
     });
   }
 
-  private parseArgs(message: Message, prefix: string, isDM: boolean): [commandName: CommandStructureBased | null, commandArgs: MsgArgs[]] {
+  private parseArgs(message: Message, prefix: string, isDM: boolean): [commandName: CommandStructureBased | null, commandArgs: MsgArgsMap | null] {
     const args = message.content.slice(prefix.length).trim().split(/ +/);
     const commandName = args.shift()?.toLowerCase();
 
-    if (!commandName) return [null, []];
+    if (!commandName) return [null, null];
 
     const command = this.manager.getCommand(commandName);
-    if (!command) return [null, []];
+    if (!command) return [null, null];
 
     if (!command.isDMAllowed() && isDM) {
       message.reply({ embeds: [
@@ -132,7 +132,7 @@ export class MessageHandler {
       },
       }).catch();
 
-      return [null, []];
+      return [null, null];
     }
 
     const errorEmbed = new RichEmbed()
@@ -140,18 +140,42 @@ export class MessageHandler {
       .setColor('Red')
       .setTimestamp();
 
-    const requiredParams = command.getParameters().filter((param) => param.required);
-    if (requiredParams.length > args.length) {
-      // TODO: Allow custom error message
+    const parameters = command.getParameters().filter((param) => (
+      param.type !== ApplicationCommandOptionType.Subcommand &&
+      param.type !== ApplicationCommandOptionType.SubcommandGroup
+    ));
+    const commandUsage = parameters.map((param) => {
+      if (param.required) return `<${param.name}=...>`;
+      return `[${param.name}=...]`;
+    }).join(' ');
+
+    const availableParameterNames = new Set(parameters.map((param) => param.name.toLowerCase()));
+    const namedRawArgs = new Map<string, string>();
+    const positionalRawArgs: string[] = [];
+    const unknownNamedArgs: string[] = [];
+
+    for (const rawArg of args) {
+      const namedMatch = rawArg.match(/^--?([^:=\s]+)[:=](.*)$/);
+      if (namedMatch) {
+        const paramName = namedMatch[1].toLowerCase();
+        if (!availableParameterNames.has(paramName)) {
+          unknownNamedArgs.push(paramName);
+          continue;
+        }
+
+        namedRawArgs.set(paramName, namedMatch[2]);
+        continue;
+      }
+
+      positionalRawArgs.push(rawArg);
+    }
+
+    if (unknownNamedArgs.length > 0) {
       message.reply(this.listener.replyParser(
         errorEmbed
-          .setTitle('Missing Arguments')
-          .setDescription(`Command Usage: \`${prefix}${commandName} ${requiredParams.map((param) => {
-            if (!param.required) return `[${param.name}]`;
-            return `<${param.name}>`;
-          }).join(' ')}\``),
+          .setDescription(`Unknown named argument(s): ${unknownNamedArgs.map((param) => `\`${param}\``).join(', ')}.`),
       )).catch();
-      return [null, []];
+      return [null, null];
     }
 
     const users = message.mentions.users.values().toArray();
@@ -159,122 +183,153 @@ export class MessageHandler {
     const channels = message.mentions.channels.values().toArray();
     const attachments = message.attachments.values().toArray();
 
-    const commandArgs: MsgArgs[] = [];
-    for (const param of command.getParameters()) {
-      if (param.required && args.length === 0) {
-        // If a required parameter is missing, we stop parsing
-        break;
+    const commandArgs: MsgArgsMap = new Map();
+    for (let index = 0; index < parameters.length; index++) {
+      const param = parameters[index];
+      const paramName = param.name.toLowerCase();
+      const hasNamedArg = namedRawArgs.has(paramName);
+
+      let rawArg = hasNamedArg ? namedRawArgs.get(paramName) : positionalRawArgs.shift();
+
+      if (!hasNamedArg &&
+        rawArg !== undefined &&
+        param.type === ApplicationCommandOptionType.String &&
+        index === parameters.length - 1 &&
+        positionalRawArgs.length > 0) {
+        rawArg = [rawArg, ...positionalRawArgs].join(' ');
+        positionalRawArgs.length = 0;
       }
 
-      const arg = args.shift();
-      if (!arg) {
+      if (rawArg === undefined || rawArg.length === 0) {
+        if (param.required) {
+          message.reply(this.listener.replyParser(
+            errorEmbed
+              .setTitle('Missing Arguments')
+              .setDescription(`Command Usage: \`${prefix}${commandName} ${commandUsage}\``),
+          )).catch();
+          return [null, null];
+        }
+
         continue;
       }
 
-      if (param.choices && !param.choices.some(choice => choice.value === arg)) {
+      if (param.choices && !param.choices.some(choice => choice.value === rawArg)) {
         message.reply(this.listener.replyParser(
           errorEmbed
             .setDescription(`The argument \`${param.name}\` must be one of the following: ${param.choices.map(choice => `\`${choice.value}\``).join(', ')}.`),
         )).catch();
-        return [null, []];
+        return [null, null];
       }
 
-      let parsedArg: MsgArgs;
+      let parsedArg: MsgArgs | undefined;
       
       switch (param.type) {
         case ApplicationCommandOptionType.String:
-          if (arg.length < (param.min_length ?? 0) || arg.length > (param.max_length ?? 2000)) {
+          if (rawArg.length < (param.min_length ?? 0) || rawArg.length > (param.max_length ?? 2000)) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be between ${param.min_length ?? 0} and ${param.max_length ?? 2000} characters long.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
-          parsedArg = arg;
+          parsedArg = rawArg;
           break;
         case ApplicationCommandOptionType.Integer: {
-          const intVal = parseInt(arg, 10);
-          if (isNaN(intVal) || !Number.isInteger(intVal)) {
+          if (!/^-?\d+$/.test(rawArg)) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid integer.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
+
+          const intVal = parseInt(rawArg, 10);
           if (intVal < (param.min_value ?? Number.MIN_SAFE_INTEGER) || intVal > (param.max_value ?? Number.MAX_SAFE_INTEGER)) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be between ${param.min_value ?? Number.MIN_SAFE_INTEGER} and ${param.max_value ?? Number.MAX_SAFE_INTEGER}.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           parsedArg = intVal;
           break;
         }
         case ApplicationCommandOptionType.Number: {
-          const floatVal = parseFloat(arg);
+          const floatVal = Number(rawArg);
           if (isNaN(floatVal)) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid number.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           if (floatVal < (param.min_value ?? Number.MIN_SAFE_INTEGER) || floatVal > (param.max_value ?? Number.MAX_SAFE_INTEGER)) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be between ${param.min_value ?? Number.MIN_SAFE_INTEGER} and ${param.max_value ?? Number.MAX_SAFE_INTEGER}.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           parsedArg = floatVal;
           break;
         }
         case ApplicationCommandOptionType.Boolean:
-          if (arg.toLowerCase() === 'true' || arg === '1') {
+          if (rawArg.toLowerCase() === 'true' || rawArg === '1') {
             parsedArg = true;
-          } else if (arg.toLowerCase() === 'false' || arg === '0') {
+          } else if (rawArg.toLowerCase() === 'false' || rawArg === '0') {
             parsedArg = false;
           } else {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid boolean (true/false).`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           break;
         case ApplicationCommandOptionType.User: {
-          const user = users.shift() || this.client.users.cache.get(arg);
+          const userId = rawArg.replace(/[<@!>]/g, '');
+          const user = message.mentions.users.get(userId) || users.shift() || this.client.users.cache.get(userId) || this.client.users.cache.get(rawArg);
           if (!user) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid user mention or ID.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           parsedArg = user;
           break;
         }
         case ApplicationCommandOptionType.Channel: {
-          const channel = (channels.shift() || this.client.channels.cache.get(arg)) as GuildBasedChannel | undefined;
+          const channelId = rawArg.replace(/[<#>]/g, '');
+          const channel = (message.mentions.channels.get(channelId) ||
+            channels.shift() ||
+            this.client.channels.cache.get(channelId) ||
+            this.client.channels.cache.get(rawArg)
+          ) as GuildBasedChannel | undefined;
+          
           if (!channel) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid channel mention or ID.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           parsedArg = channel;
           break;
         }
         case ApplicationCommandOptionType.Role: {
-          const role = roles.shift() || this.client.guilds.cache.get(message.guildId!)?.roles.cache.get(arg);
+          const roleId = rawArg.replace(/[<@&>]/g, '');
+          const role = message.mentions.roles.get(roleId) ||
+            roles.shift() ||
+            this.client.guilds.cache.get(message.guildId!)?.roles.cache.get(roleId) ||
+            this.client.guilds.cache.get(message.guildId!)?.roles.cache.get(rawArg);
+
           if (!role) {
             message.reply(this.listener.replyParser(
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid role mention or ID.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           parsedArg = role;
           break;
@@ -286,13 +341,13 @@ export class MessageHandler {
               errorEmbed
                 .setDescription(`The argument \`${param.name}\` must be a valid attachment.`),
             )).catch();
-            return [null, []];
+            return [null, null];
           }
           parsedArg = attachment;
           break;
         }
         case ApplicationCommandOptionType.Mentionable:
-          parsedArg = arg;
+          parsedArg = rawArg;
           break;
         case ApplicationCommandOptionType.Subcommand:
         case ApplicationCommandOptionType.SubcommandGroup:
@@ -300,14 +355,19 @@ export class MessageHandler {
           break;
       }
 
-      if (!parsedArg) continue;
+      if (parsedArg === undefined || parsedArg === null) continue;
 
-      commandArgs.push(parsedArg);
+      commandArgs.set(paramName, parsedArg);
     }
 
-    if (args.length > 0) {
-      commandArgs.push(args.join(' '));
+    if (positionalRawArgs.length > 0) {
+      message.reply(this.listener.replyParser(
+        errorEmbed
+          .setDescription(`Unexpected extra argument(s): ${positionalRawArgs.map((arg) => `\`${arg}\``).join(', ')}.`),
+      )).catch();
+      return [null, null];
     }
+
     return [command, commandArgs];
   }
 }

--- a/src/main/discord/listeners/handlers/SlashHandler.ts
+++ b/src/main/discord/listeners/handlers/SlashHandler.ts
@@ -12,7 +12,7 @@ import {
 import { CommandListener, MsgParams } from '../CommandListener';
 import { ButtonManager, CommandManager } from '../../managers';
 import { MessageStructure } from '../../structures';
-import { ICommandContext } from '../../interfaces';
+import { ICommandContext, MsgArgs } from '../../interfaces';
 import { DiscordClient } from '../../Client';
 
 export class SlashHandler {
@@ -32,26 +32,37 @@ export class SlashHandler {
     }
     if (!ctx.isCommand()) return;
 
+    const parsedArgs = new Map<string, MsgArgs>();
+    (ctx as ChatInputCommandInteraction).options.data.forEach((arg) => {
+      let value: MsgArgs;
+      switch (arg.type) {
+        case ApplicationCommandOptionType.User:
+          value = arg.user;
+          break;
+        case ApplicationCommandOptionType.Role:
+          value = arg.role;
+          break;
+        case ApplicationCommandOptionType.Channel:
+          value = arg.channel;
+          break;
+        case ApplicationCommandOptionType.Attachment:
+          value = arg.attachment;
+          break;
+        default:
+          value = arg.value as MsgArgs;
+          break;
+      }
+
+      parsedArgs.set(arg.name.toLowerCase(), value);
+    });
+
     const context: ICommandContext = {
       client: this.client,
       guild: ctx.guild,
       channel: ctx.channel,
       member: ctx.member as GuildMember,
       author: ctx.user,
-      args: (ctx as ChatInputCommandInteraction).options.data.map((arg) => {
-        switch (arg.type) {
-          case ApplicationCommandOptionType.User:
-            return arg.user;
-          case ApplicationCommandOptionType.Role:
-            return arg.role;
-          case ApplicationCommandOptionType.Channel:
-            return arg.channel;
-          case ApplicationCommandOptionType.Attachment:
-            return arg.attachment;
-          default:
-            return arg.value;
-        }
-      }),
+      args: parsedArgs,
       reply: async (...options: [MessageStructure] | MsgParams[]): Promise<Message<BooleanCache<any>> | InteractionResponse<boolean>> => {
         if (options.length === 1 && options[0] instanceof MessageStructure) return await ctx.reply(options[0]);
         return await ctx.reply(this.listener.replyParser(...(options as MsgParams[])));


### PR DESCRIPTION
- [BREAKING][discord]: The `args` property in `ICommandContext` is now a `Map<string, MsgArgs>` instead of `MsgArgs[]`;
  - Arguments are now keyed by their parameter name (lowercase), matching the behavior of slash commands;
  - This affects both legacy (prefix) commands and slash commands;
  - Update any code that accesses `context.args` by index (e.g. `args[0]`) to use `args.get('paramName')` instead;

- [FEAT][discord]: Legacy commands now support named arguments;
  - Arguments can be passed by name using the `--name=value` or `-name:value` syntax, in addition to the traditional positional syntax;
  - Positional and named arguments can be mixed freely;

- [FEAT][discord]: The last `String` parameter of a legacy command now automatically captures all remaining positional tokens as a single joined string;

- [FIX][discord]: Passing extra positional arguments that exceed the command's parameter count now returns a clear error message instead of silently being appended to the last argument;
  - Unknown named arguments also produce a clear error message;

- [FIX][discord]: User, channel, and role resolution now correctly strips mention formatting (e.g. `<@123>`, `<#456>`, `<@&789>`) before resolving by ID;

- [FIX][discord]: Integer validation now uses a strict regex (`/^-?\d+$/`) instead of `parseInt`, preventing strings like `"12abc"` from being accepted as valid integers;

- [FIX][discord]: Number validation now uses `Number()` instead of `parseFloat`, improving consistency with JavaScript's standard numeric coercion;

- [FIX][discord]: Subcommand and SubcommandGroup option types are now excluded from parameter iteration and the usage string, preventing them from being treated as regular arguments;

- [CHORE]: Bump dependencies;